### PR TITLE
Fix right side height

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -9,7 +9,7 @@
           <img
             src="../assets/Logo/24s-Logo-white.png"
             alt="logo"
-            class="w-28 h-28 object-contain"
+            class="h-10 w-auto object-contain"
           />
         </router-link>
         <!-- Desktop Navigation -->


### PR DESCRIPTION
Reduce logo image height in Navbar.vue to align navbar height on both sides.

---
<a href="https://cursor.com/background-agent?bcId=bc-660861e1-708f-4148-a988-3690b8517fba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-660861e1-708f-4148-a988-3690b8517fba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

